### PR TITLE
.deb + SystemD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+test-state.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 test-state.json
+*.deb

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Scans the ETH chain from WHACKD's genesis block to find WHACKD! transactions.
 
 You can install them via:
 ```
-$ pip install tqdm web3$ pip install tqdm web3
+$ pip install tqdm web3
 ```
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 ## whackdeventscanner
 Scans the ETH chain from WHACKD's genesis block to find WHACKD! transactions.
+
 # Usage
-- `git clone https://github.com/WHACKD-Foundation/whackdeventscanner.git`
-- `pip3 install tqdm` 
-- `python whackdeventscanner.py <your-infura-or-eth-node-url-here>` 
-or per your system:
-- `python3 whackdeventscanner.py <your-infura-or-eth-node-url-here>` 
+```
+$ git clone https://github.com/WHACKD-Foundation/whackdeventscanner.git
+$ pip install tqdm web3
+$ python whackdeventscanner.py <your-infura-or-eth-node-url-here>
+```
+
+Depending on your system, you might need to replace `pip` for `pip3`, and `python` for `python3`.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
 ## whackdeventscanner
 Scans the ETH chain from WHACKD's genesis block to find WHACKD! transactions.
 
+# Dependencies
+
+- [tdqm](https://pypi.org/project/tqdm/)
+- [web3](https://pypi.org/project/web3/)
+
+You can install them via:
+```
+$ pip install tqdm web3$ pip install tqdm web3
+```
+
 # Usage
 ```
 $ git clone https://github.com/WHACKD-Foundation/whackdeventscanner.git
-$ pip install tqdm web3
 $ python whackdeventscanner.py <your-infura-or-eth-node-url-here>
 ```
 

--- a/pkg/create_pkg.sh
+++ b/pkg/create_pkg.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+mkdir -p var/lib/whackd
+mkdir -p usr/bin
+
+cp ../whackdeventscanner.py usr/bin/whackd
+chmod +x usr/bin/whackd
+
+fpm -s dir -t deb -n whackd \
+   --deb-no-default-config-files \
+  -C . \
+  -d 'python3' \
+  -d 'dialog' \
+  -p whackd.deb \
+  --after-install ./postinst \
+  --before-remove ./prerm \
+  --after-remove ./postrm \
+  --license "GPLv3" \
+  --maintainer "The WHACKD Team" \
+  --description "Scans the ETH chain from WHACKD's genesis block to find WHACKD! transactions. RIP John McAfee." \
+  --url "https://whosgettingwhackd.com/"
+
+rm -rf var usr/bin

--- a/pkg/postinst
+++ b/pkg/postinst
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -e
+adduser --system --no-create-home --group whackd
+chown whackd:whackd /var/lib/whackd
+
+dialog_user() {
+  exec 3>&1
+
+  WEB3_HELP="To monitor the Ethereum Network for WHACKD Transactions, you need a Web3 Provider such as infura.io or your own Eth1 node (ex.: Go-Ethereum, OpenEthereum, Trinity, Nimbus).
+Please provide an URL for a Web3 Provider.
+  
+ex.: https://mainnet.infura.io/v3/xxx"
+
+  WEB3_URL=$(dialog --title "Eth1 Web3 Provider" \
+    --clear \
+    --inputbox "${WEB3_HELP}" 20 110 2>&1 1>&3)
+
+  # check for empty Web3 Provider
+  if [ -z $WEB3_URL ]; then
+    echo "You didn't provide any Eth1 Web3 Provider.
+You should fix this by editing /usr/lib/systemd/system/whackd.service and setting proper value on WEB3_URL."
+  fi
+
+  # check for Web3 Provider URL prefixes (https:// or wss://)
+  if [[ !( -z $WEB3_URL ) && !( $WEB3_URL =~ ^https\:\/\/.* || $WEB3_URL =~ ^wss\:\/\/.* ) ]]; then
+    echo "You provided an invalid Eth1 Web3 Provider. You should fix this by editing /usr/lib/systemd/system/whackd.service and setting proper value on WEB3_URL"
+  fi
+
+  echo "Environment=WEB3_URL=${WEB3_URL}" >>/usr/lib/systemd/system/whackd.service
+}
+
+while true; do
+  read -p "Do you want to be assisted in the configuration of the WHACKD SystemD Service? y/n " yn
+  case $yn in
+  [Yy]*)
+    dialog_user
+    break
+    ;;
+  [Nn]*)
+    echo "Warning: you must manually edit /usr/lib/systemd/system/whackd.service and setting proper values on WEB3_URL."
+    echo "Environment=WEB3_URL=" >>/usr/lib/systemd/system/whackd.service
+    exit
+    ;;
+  *) echo "Please answer yes or no." ;;
+  esac
+done
+

--- a/pkg/postrm
+++ b/pkg/postrm
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+rm -rf /var/lib/whackd
+rm -rf /usr/lib/systemd/system/whackd.service
+userdel whackd

--- a/pkg/prerm
+++ b/pkg/prerm
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+if (systemctl is-active --quiet whackd.service)
+	then
+	systemctl stop whackd.service
+	systemctl disable whackd.service
+fi

--- a/pkg/usr/lib/systemd/system/whackd.service
+++ b/pkg/usr/lib/systemd/system/whackd.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=WHACKD Event Scanner
+Wants=network-online.target
+After=network-online.target
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+LimitNOFILE=4096
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=whackd
+PrivateDevices=yes
+PrivateTmp=yes
+ProtectSystem=full
+ProtectHome=yes
+
+User=whackd
+WorkingDirectory=/var/lib/whackd
+TimeoutSec=1200
+Restart=always
+ExecStart=/usr/bin/whackd ${WEB3_URL}

--- a/whackdeventscanner.py
+++ b/whackdeventscanner.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """A stateful event scanner for Ethereum-based blockchains using Web3.py.
 
 With the stateful mechanism, you can do one batch scan or incremental scans,


### PR DESCRIPTION
Adds SystemD Service.

Since a SystemD Service Unit expects the executable to be placed on a specific path, I also wrote a script to create a `.deb` package. It uses [FPM](https://fpm.readthedocs.io/en/latest/) and can easily be adapted into different package formats.

`whackdeventscanner.py` is installed as `/usr/bin/whackd`.

# Usage

Just execute `create_pkg.sh` and it will spit out `whackd.deb`. Install it in the target system.
An interactive system based on [dialog](https://linux.die.net/man/1/dialog) asks for the Web3 provider URL.
In case the dialog is cancelled, the user must edit `/usr/lib/systemd/system/whackd.service` manually and fill `WEB3_URL` in.

# Limitations

In case the target system does not contain `tdqm` and `web3` Python modules, the Service will fail.